### PR TITLE
Adopt Go version to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.17.x'
+          go-version: '1.18.x'
 
       - name: Check go.mod and go.sum are tidy
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Install Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
+          version: v1.45
 
       - name: Run Lint
         run: |


### PR DESCRIPTION
This commit was accidentally left out of #4.