### PR TITLE
update to golangci-lint 1.47, from sylabs 66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.47
 
       - name: Run Lint
         run: |


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/scs-key-client#66